### PR TITLE
Support multiple meetings on the same day (#17)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+    - '*.gemspec'
 Metrics/MethodLength:
   Max: 25
 Metrics/AbcSize:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 0.6.3
+
+Support multiple meetings on the same day. Previously the second meeting on a
+given day overwrote the first, since entries were keyed only by date. Same-day
+meetings now get the Indico event id appended to their key (`YYYYMMDD-<id>`);
+days with a single meeting are unaffected.
+
 # Version 0.6.2
 
 Fix one more issue with caching.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jekyll-indico (0.6.2)
+    jekyll-indico (0.6.3)
       jekyll (>= 3.8, < 5.0)
 
 GEM

--- a/lib/jekyll-indico/core.rb
+++ b/lib/jekyll-indico/core.rb
@@ -24,32 +24,44 @@ module JekyllIndico
 
     # ID for IRIS-HEP: 10570
     def initialize(base_url, indico_id, limit: nil, **kargs)
-      @dict = {}
+      results = []
+      download_and_iterate(base_url, indico_id, limit: limit, **kargs) { |i| results << i }
+      @dict = self.class.build(results)
+    end
 
-      download_and_iterate(base_url, indico_id, limit: limit, **kargs) do |i|
-        # Trim paragraph tags
-        d = i['description']
-        d = d[3..] if d.start_with? '<p>'
-        d = d[0..-5] if d.end_with? '</p>'
-
-        start_date = Date.parse i['startDate']['date']
-        fname = start_date.strftime('%Y%m%d').to_s
-
-        youtube = ''
-        urllist = URI.extract(d)
-        urllist.each do |url|
-          youtube = url if url.include?('youtube') || url.include?('youtu.be')
-        end
-
-        @dict[fname] = {
-          'name' => i['title'],
-          'startdate' => start_date,
-          'meetingurl' => i['url'],
-          'location' => i['location'],
-          'youtube' => youtube,
-          'description' => d
-        }
+    # Build the date-keyed meeting hash from raw Indico results.
+    def self.build(results)
+      dict = {}
+      results.each do |i|
+        meeting = entry(i)
+        key = meeting['startdate'].strftime('%Y%m%d').to_s
+        # Disambiguate multiple meetings on the same day with the event id (#17)
+        key = "#{key}-#{i['id']}" if dict.key?(key)
+        dict[key] = meeting
       end
+      dict
+    end
+
+    # Transform a single Indico result into a meeting hash.
+    def self.entry(item)
+      # Trim paragraph tags
+      d = item['description']
+      d = d[3..] if d.start_with? '<p>'
+      d = d[0..-5] if d.end_with? '</p>'
+
+      youtube = ''
+      URI.extract(d).each do |url|
+        youtube = url if url.include?('youtube') || url.include?('youtu.be')
+      end
+
+      {
+        'name' => item['title'],
+        'startdate' => Date.parse(item['startDate']['date']),
+        'meetingurl' => item['url'],
+        'location' => item['location'],
+        'youtube' => youtube,
+        'description' => d
+      }
     end
 
     # Write out files (Folder given, by key name)

--- a/lib/jekyll-indico/version.rb
+++ b/lib/jekyll-indico/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JekyllIndico
-  VERSION = '0.6.2'
+  VERSION = '0.6.3'
 end

--- a/spec/jekyll-indico_spec.rb
+++ b/spec/jekyll-indico_spec.rb
@@ -30,4 +30,24 @@ RSpec.describe JekyllIndico do
       expect(@meeting.dict['20200909']['youtube']).to eq('https://youtu.be/26YXz0fzMNQ')
     end
   end
+
+  context 'with multiple meetings on the same day' do
+    def result(id, title)
+      {
+        'id' => id,
+        'title' => title,
+        'description' => '<p>A meeting</p>',
+        'startDate' => { 'date' => '2024-03-04' },
+        'url' => "https://indico.cern.ch/event/#{id}/",
+        'location' => 'CERN'
+      }
+    end
+
+    it 'keeps both meetings, disambiguated by event id' do
+      dict = JekyllIndico::Meetings.build([result('111', 'First'), result('222', 'Second')])
+      expect(dict.keys).to contain_exactly('20240304', '20240304-222')
+      expect(dict['20240304']['name']).to eq('First')
+      expect(dict['20240304-222']['name']).to eq('Second')
+    end
+  end
 end


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes #17.

## Problem

`Meetings` keyed `@dict` solely by start date (`YYYYMMDD`). A second meeting on the same day silently overwrote the first, and the cache wrote both to the same `YYYYMMDD.yml` file.

## Change

Same-day meetings now get the Indico event id appended to their key (`YYYYMMDD-<id>`). The **first** meeting on a day keeps the bare `YYYYMMDD` key, so existing single-per-day sites, cached files, and the live specs are unaffected — only collisions are disambiguated.

The per-result transform is split out of the constructor into pure class methods (`Meetings.build` / `Meetings.entry`) so the dedup logic is unit-testable without hitting the Indico API (the live test category currently has no same-day collisions).

## Notes

The issue suggested keying by URL instead of date. This keeps the date as the primary key (preserving chronological sort order and backward compatibility) and only appends the id on collision. Making every key uniformly `YYYYMMDD-<id>` is a one-line change but breaking for templates that look meetings up by exact date — happy to switch if preferred.

`bundle exec rake` (rubocop + rspec, 10 examples) passes.