### PR TITLE
fix: raise clear error on non-2xx Indico HTTP response

### DIFF
--- a/lib/jekyll-indico/core.rb
+++ b/lib/jekyll-indico/core.rb
@@ -90,6 +90,10 @@ module JekyllIndico
 
       response = Net::HTTP.start(uri.hostname, uri.port, **opts) { |http| http.request(req) }
 
+      unless response.is_a?(Net::HTTPSuccess)
+        raise Error, "Indico request failed (#{response.code} #{response.message}) for #{uri}"
+      end
+
       parsed = JSON.parse(response.body)
       parsed['results']
     end


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Raises `JekyllIndico::Error` with the HTTP status code, message, and request URI when the Indico API returns a non-2xx response. Previously, a failed response (auth error, bad category id, redirect that `Net::HTTP` does not auto-follow) would cause `JSON.parse` to succeed on an error page body and then return `nil` from `parsed['results']`, producing an opaque `NoMethodError` far from the root cause.

Refs #23