### PR TITLE
fix: guard against nil description in Meetings.entry

### DIFF
--- a/lib/jekyll-indico/core.rb
+++ b/lib/jekyll-indico/core.rb
@@ -45,7 +45,7 @@ module JekyllIndico
     # Transform a single Indico result into a meeting hash.
     def self.entry(item)
       # Trim paragraph tags
-      d = item['description']
+      d = item['description'].to_s
       d = d[3..] if d.start_with? '<p>'
       d = d[0..-5] if d.end_with? '</p>'
 

--- a/spec/jekyll-indico_spec.rb
+++ b/spec/jekyll-indico_spec.rb
@@ -49,5 +49,20 @@ RSpec.describe JekyllIndico do
       expect(dict['20240304']['name']).to eq('First')
       expect(dict['20240304-222']['name']).to eq('Second')
     end
+
+    it 'handles a nil description without raising' do
+      item = {
+        'id' => '333',
+        'title' => 'No Description',
+        'description' => nil,
+        'startDate' => { 'date' => '2024-03-05' },
+        'url' => 'https://indico.cern.ch/event/333/',
+        'location' => 'CERN'
+      }
+      expect { JekyllIndico::Meetings.build([item]) }.not_to raise_error
+      dict = JekyllIndico::Meetings.build([item])
+      expect(dict['20240305']['description']).to eq('')
+      expect(dict['20240305']['youtube']).to eq('')
+    end
   end
 end


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Guard against a `NoMethodError` when Indico returns a `null` description field. Calling `.to_s` on the raw value converts `nil` to `""` before the `start_with?` check, so the existing trimming and `URI.extract` logic handle it cleanly without further changes.

A regression test is added in the offline `'with multiple meetings on the same day'` context that builds a result with `'description' => nil` and asserts no exception is raised and the output has `'description' => ''` and `'youtube' => ''`.

Refs #23