### PR TITLE
chore: add Dependabot, modernize counter, drop unused require (#23 items 10-12)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/lib/jekyll-indico/core.rb
+++ b/lib/jekyll-indico/core.rb
@@ -5,7 +5,6 @@ require 'uri'
 require 'json'
 require 'yaml'
 require 'date'
-require 'time'
 require 'openssl'
 
 module JekyllIndico
@@ -104,7 +103,7 @@ module JekyllIndico
         return
       end
 
-      0.step.each do |n|
+      (0..).each do |n|
         results = get_parsed_results(base_url, indico_id, offset: n * limit, limit: limit, **params)
         results.each(&block)
         break if results.length < limit


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Three small modernizations from issue #23:

- **Item 10** — Add `.github/dependabot.yml` to enable weekly Dependabot updates for GitHub Actions workflows.
- **Item 11** — Replace `0.step.each do |n|` with `(0..).each do |n|` (idiomatic endless range, available since Ruby 2.6).
- **Item 12** — Remove `require 'time'` from `lib/jekyll-indico/core.rb`; only `Date.parse` is used, not `Time`. `require 'openssl'` is retained as it guards SSL for `Net::HTTP`.

All three changes are behavior-neutral. Verified with `rubocop` (no offenses), `rspec` `multiple meetings` example (passes), and a clean `ruby -Ilib -e "require 'jekyll-indico/core'"` load check.

Refs #23