### PR TITLE
test: fix field-coverage loop to use iterated variable

### DIFF
--- a/spec/jekyll-indico_spec.rb
+++ b/spec/jekyll-indico_spec.rb
@@ -19,9 +19,7 @@ RSpec.describe JekyllIndico do
 
     %w[name startdate meetingurl location youtube description].each do |name|
       it "has a #{name} field" do
-        expect(@meeting.dict['20190128']).to include('name')
-        expect(@meeting.dict['20190128']).to include('startdate')
-        expect(@meeting.dict['20190128']).to include('meetingurl')
+        expect(@meeting.dict['20190128']).to include(name)
       end
     end
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The `%w[name startdate meetingurl location youtube description].each do |name|` loop in `spec/jekyll-indico_spec.rb` never used the block variable `name`. All six generated examples asserted the same three hardcoded fields (`'name'`, `'startdate'`, `'meetingurl'`), leaving `location`, `youtube`, and `description` completely unchecked.

This replaces the three hardcoded `expect` lines with a single `expect(@meeting.dict['20190128']).to include(name)`, so each iteration properly tests its own field.

Refs #23