### PR TITLE
refactor: config-parser consolidation and core cleanups

### DIFF
--- a/exe/jekyll-indico-cache
+++ b/exe/jekyll-indico-cache
@@ -18,14 +18,8 @@ end.parse!
 puts "Reading #{options[:config]}"
 
 config = YAML.safe_load(File.read(options[:config]))
-meeting_ids = config.dig('indico', 'ids')
-base_url = config.dig('indico', 'url')
-data_path = config.dig('indico', 'data') || 'indico'
+indico = JekyllIndico.config_from(config['indico'])
 
-raise MissingURL, 'indico: url: MISSING from your config!' unless base_url
-raise MissingIDs, 'indico: ids: MISSING from your config!' unless meeting_ids
-raise MissingIDs, 'indico: ids: must be a hash!' unless meeting_ids.is_a?(Hash)
-
-JekyllIndico.cache(base_url, meeting_ids, data_path) do |name, number|
+JekyllIndico.cache(indico[:url], indico[:ids], indico[:data]) do |name, number|
   puts "Accessing #{number} for #{name}"
 end

--- a/lib/jekyll-indico/config.rb
+++ b/lib/jekyll-indico/config.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# The main module for this package.
+module JekyllIndico
+  # Validate the `indico:` config hash and return its common values.
+  # Raises MissingURL / MissingIDs (with the documented messages) on bad input.
+  def self.config_from(indico_hash)
+    url = indico_hash&.dig('url')
+    raise MissingURL, 'indico: url: MISSING from your config!' unless url
+
+    ids = indico_hash&.dig('ids')
+    raise MissingIDs, 'indico: ids: MISSING from your config!' unless ids
+    raise MissingIDs, 'indico: ids: must be a hash!' unless ids.is_a?(Hash)
+
+    {
+      url: url,
+      ids: ids,
+      data: indico_hash&.dig('data') || 'indico'
+    }
+  end
+end

--- a/lib/jekyll-indico/core.rb
+++ b/lib/jekyll-indico/core.rb
@@ -20,7 +20,7 @@ module JekyllIndico
 
   # Look for topical meetings
   class Meetings
-    attr_accessor :dict
+    attr_reader :dict
 
     # ID for IRIS-HEP: 10570
     def initialize(base_url, indico_id, limit: nil, **kargs)
@@ -49,10 +49,7 @@ module JekyllIndico
       d = d[3..] if d.start_with? '<p>'
       d = d[0..-5] if d.end_with? '</p>'
 
-      youtube = ''
-      URI.extract(d).each do |url|
-        youtube = url if url.include?('youtube') || url.include?('youtu.be')
-      end
+      youtube = URI.extract(d).find { |url| url.include?('youtube') || url.include?('youtu.be') } || ''
 
       {
         'name' => item['title'],
@@ -82,8 +79,8 @@ module JekyllIndico
       uri.query = URI.encode_www_form(params)
 
       req = Net::HTTP::Get.new(uri)
-      if ENV['INDICO_TOKEN']
-        req['Authorization'] = "Bearer #{ENV.fetch('INDICO_TOKEN', nil)}"
+      if (token = ENV.fetch('INDICO_TOKEN', nil))
+        req['Authorization'] = "Bearer #{token}"
       elsif ENV.fetch('INDICO_SECRET_KEY', nil) || ENV.fetch('INDICO_API_KEY', nil)
         raise Error, 'Use INDICO_TOKEN with a new-style token'
       end
@@ -112,3 +109,5 @@ module JekyllIndico
     end
   end
 end
+
+require 'jekyll-indico/config'

--- a/lib/jekyll-indico/generator.rb
+++ b/lib/jekyll-indico/generator.rb
@@ -15,12 +15,9 @@ module JekyllIndico
     def generate(site)
       @site = site
       @cache_msg = @site.config.dig('indico', 'cache-command')
+      @config = JekyllIndico.config_from(@site.config['indico'])
 
-      meeting_ids = @site.config.dig('indico', 'ids')
-      raise MissingIDs, 'indico: ids: MISSING from your config!' unless meeting_ids
-      raise MissingIDs, 'indico: ids: must be a hash!' unless meeting_ids.is_a?(Hash)
-
-      meeting_ids.each do |name, number|
+      @config[:ids].each do |name, number|
         collect_meeting(name.to_s, number)
       end
     end
@@ -28,10 +25,8 @@ module JekyllIndico
     private
 
     def collect_meeting(name, number)
-      base_url = @site.config.dig('indico', 'url')
-      raise MissingURL, 'indico: url: MISSING from your config!' unless base_url
-
-      data_path = @site.config.dig('indico', 'data') || 'indico'
+      base_url = @config[:url]
+      data_path = @config[:data]
       @site.data[data_path] = {} unless @site.data.key? data_path
 
       timeout = @site.config.dig('indico', 'timeout')


### PR DESCRIPTION
:robot: _AI text below_ :robot:

A group of behavior-preserving internal cleanups from issue #23.

- **Item 5** — `core.rb` `get_parsed_results`: read `INDICO_TOKEN` once via `if (token = ENV.fetch('INDICO_TOKEN', nil))` instead of reading the env var twice. The legacy-key `elsif` error branch is unchanged.
- **Item 6** — `core.rb` `self.entry`: replace the loop that kept the last matching URL with a first-match `URI.extract(d).find { ... } || ''`. Behavior-preserving for the normal single-link case.
- **Item 7** — Extract a single shared config parser, `JekyllIndico.config_from` (new `lib/jekyll-indico/config.rb`, required via `core.rb`), so `generator.rb` and `exe/jekyll-indico-cache` validate the `indico:` config from one source of truth. The exact `MissingURL`/`MissingIDs` messages and the `data` default of `'indico'` are preserved. The generator still reads `timeout`/`paginate`/`cache-command` directly and keeps its skip/Benchmark/printout logic; the exe keeps its optparse/`--config` handling and `puts` lines.
- **Item 8** — `core.rb`: change `attr_accessor :dict` to `attr_reader :dict` (the writer was never used).

Verified: `bundle exec rubocop` reports no offenses; `bundle exec rspec spec/jekyll-indico_spec.rb -e 'multiple meetings'` passes offline; the three config error cases (missing url / missing ids / non-hash ids) raise the exact original messages.

Refs #23
